### PR TITLE
add schema dependencies

### DIFF
--- a/src/joi/generate.ts
+++ b/src/joi/generate.ts
@@ -86,7 +86,7 @@ export function generateJoi(schema: JoiSchema, withTitle: boolean = false): JoiS
 
 export function generateAnyJoi(schema: JoiAny): JoiStatement[] {
   let content: JoiStatement[]
-    = (schema.type === 'any') ? openJoi(['Joi.any()']) : [];
+    = (schema.type === 'any') ? openJoi(['Joi.any()']) : []; // TODO: Here have some problems with pattern 
   if (schema.allow) {
     content.push(`.allow(${JSON.stringify(schema.allow)})`);
   }
@@ -108,7 +108,6 @@ export function generateAnyJoi(schema: JoiAny): JoiStatement[] {
   // if (schema.description) {
   //   content.push(`.description(${JSON.stringify(schema.description)})`);
   // }
-
   return (schema.type === 'any') ? closeJoi(content) : content;
 }
 

--- a/src/joi/generate.ts
+++ b/src/joi/generate.ts
@@ -86,7 +86,7 @@ export function generateJoi(schema: JoiSchema, withTitle: boolean = false): JoiS
 
 export function generateAnyJoi(schema: JoiAny): JoiStatement[] {
   let content: JoiStatement[]
-    = (schema.type === 'any') ? openJoi(['Joi.any()']) : []; // TODO: Here have some problems with pattern 
+    = (schema.type === 'any') ? openJoi(['Joi.any()']) : [];  
   if (schema.allow) {
     content.push(`.allow(${JSON.stringify(schema.allow)})`);
   }

--- a/src/joi/generate.ts
+++ b/src/joi/generate.ts
@@ -86,7 +86,7 @@ export function generateJoi(schema: JoiSchema, withTitle: boolean = false): JoiS
 
 export function generateAnyJoi(schema: JoiAny): JoiStatement[] {
   let content: JoiStatement[]
-    = (schema.type === 'any') ? openJoi(['Joi.any()']) : [];  
+    = (schema.type === 'any') ? openJoi(['Joi.any()']) : [];
   if (schema.allow) {
     content.push(`.allow(${JSON.stringify(schema.allow)})`);
   }

--- a/src/joi/object.ts
+++ b/src/joi/object.ts
@@ -172,7 +172,7 @@ export function generateObjectJoi(schema: JoiObject): JoiStatement[] {
 
       content.push(JoiSpecialChar.CLOSE_PAREN);
 
-      content.push('\n');
+      content.push(JoiSpecialChar.NEWLINE);
     });
 
   }
@@ -191,12 +191,14 @@ export function generateObjectJoi(schema: JoiObject): JoiStatement[] {
         content.push(JoiSpecialChar.OPEN_BRACKET);
         content.push(stringifyOutputString(dependencies).join(','));
         content.push(JoiSpecialChar.CLOSE_BRACKET);
+        content.push(' ');
       } else {
         // TODO Joi.with() can't not support object dependencies
         // content.push(...generateJoi(dependencies));
       }
       content.push(JoiSpecialChar.CLOSE_PAREN);
-      content.push('\n');
+
+      content.push(JoiSpecialChar.NEWLINE);
     });
   }
   content.push(...generateAnyJoi(schema));

--- a/src/joi/object.ts
+++ b/src/joi/object.ts
@@ -46,7 +46,6 @@ function resolveProperties(schema: JSONSchema4, options?: Options): { [k: string
 }
 
 export function resolveJoiObjectSchema(schema: JSONSchema4, options?: Options): JoiObject {
-  // JoiObject is a customized object type used to describe the final string.
   const joiSchema = createJoiItem('object') as JoiObject;
   // https://json-schema.org/understanding-json-schema/reference/object.html#properties
   joiSchema.keys = resolveProperties(schema, options);
@@ -57,14 +56,11 @@ export function resolveJoiObjectSchema(schema: JSONSchema4, options?: Options): 
   if (typeof additionalProperties === 'boolean') {
     joiSchema.unknown = additionalProperties;
   } else {
-    //  TODO : additionalProperties may not be object or string!
-    // TODO : the resolve of additionalProperties is not properly when the additionalProperties is not boolean type.
     joiSchema.pattern = [{
       pattern: '^',
       schema: resolveJSONSchema(additionalProperties, options),
     }];
   }
-
   // https://json-schema.org/understanding-json-schema/reference/object.html#size
   // tslint:disable:no-unused-expression-chai
   if(_.isNumber(schema.minProperties) && _.isNumber(schema.maxProperties) && schema.maxProperties == schema.minProperties) {
@@ -75,7 +71,7 @@ export function resolveJoiObjectSchema(schema: JSONSchema4, options?: Options): 
   }
   // tslint:enable:no-unused-expression-chai
   // TODO: Dependencies
-  //   https://json-schema.org/understanding-json-schema/reference/object.html#dependencies
+  // https://json-schema.org/understanding-json-schema/reference/object.html#dependencies
   if(schema.dependencies !== undefined){
     // the properties which need dependencies
     let dependencies: string[] = _.keys(schema.dependencies);
@@ -84,12 +80,12 @@ export function resolveJoiObjectSchema(schema: JSONSchema4, options?: Options): 
     const joiSchemaWith = joiSchema.with;
     dependencies.forEach((key)=>{
       // https://json-schema.org/understanding-json-schema/reference/object.html#dependencies
-      // The value of the dependencies keyword is an object. Each entry in the object maps from the name of a property, p, to an array of strings listing properties that are required whenever p is present.
       if(_.isArray(schemaDepencies[key])){
         const properties:string[] = schemaDepencies[key] as string[];
         joiSchemaWith[key] = properties;
       }else{
-        //joiSchemaWith[key] = resolveJSONSchema(schemaDepencies[key],options)
+        // TODO Joi.with() can't not support object dependencies
+        // joiSchemaWith[key] = resolveJSONSchema(schemaDepencies[key],options)
       }
     })
   }
@@ -191,6 +187,7 @@ export function generateObjectJoi(schema: JoiObject): JoiStatement[] {
         content.push(...stringifyOutputString(dependencies));
         content.push(JoiSpecialChar.CLOSE_BRACKET);
       }else{
+        // TODO Joi.with() can't not support object dependencies
         //content.push(...generateJoi(dependencies));
       }
       content.push(JoiSpecialChar.CLOSE_PAREN)

--- a/src/joi/object.ts
+++ b/src/joi/object.ts
@@ -63,7 +63,9 @@ export function resolveJoiObjectSchema(schema: JSONSchema4, options?: Options): 
   }
   // https://json-schema.org/understanding-json-schema/reference/object.html#size
   // tslint:disable:no-unused-expression-chai
-  if (_.isNumber(schema.minProperties) && _.isNumber(schema.maxProperties) && schema.maxProperties == schema.minProperties) {
+  if (_.isNumber(schema.minProperties)
+    && _.isNumber(schema.maxProperties)
+    && schema.maxProperties === schema.minProperties) {
     joiSchema.length = schema.maxProperties;
   } else {
     _.isNumber(schema.minProperties) && (joiSchema.min = schema.minProperties);
@@ -74,7 +76,7 @@ export function resolveJoiObjectSchema(schema: JSONSchema4, options?: Options): 
   // https://json-schema.org/understanding-json-schema/reference/object.html#dependencies
   if (schema.dependencies !== undefined) {
     // the properties which need dependencies
-    let dependencies: string[] = _.keys(schema.dependencies);
+    const dependencies: string[] = _.keys(schema.dependencies);
     const schemaDepencies = schema.dependencies;
     joiSchema.with = {};
     const joiSchemaWith = joiSchema.with;
@@ -87,13 +89,13 @@ export function resolveJoiObjectSchema(schema: JSONSchema4, options?: Options): 
         // TODO Joi.with() can't not support object dependencies
         // joiSchemaWith[key] = resolveJSONSchema(schemaDepencies[key],options)
       }
-    })
+    });
   }
   // TODO: Pattern Properties
   // https://json-schema.org/understanding-json-schema/reference/object.html#pattern-properties
   if (schema.patternProperties !== undefined) {
-    let propertiesPattern: string[] = _.keys(schema.patternProperties);
-    if (joiSchema.pattern === undefined) joiSchema.pattern = [];
+    const propertiesPattern: string[] = _.keys(schema.patternProperties);
+    if (joiSchema.pattern === undefined) { joiSchema.pattern = []; }
     // Compiling will fail without the following two local variable declearations.
     const joiSchemaPattern = joiSchema.pattern;
     const schemaPatternProperties = schema.patternProperties;
@@ -101,8 +103,8 @@ export function resolveJoiObjectSchema(schema: JSONSchema4, options?: Options): 
       joiSchemaPattern.push({
         pattern: keyPattern,
         schema: resolveJSONSchema(schemaPatternProperties[keyPattern], options),
-      })
-    })
+      });
+    });
   }
   return joiSchema;
 }
@@ -158,7 +160,7 @@ export function generateObjectJoi(schema: JoiObject): JoiStatement[] {
         '.pattern',
         JoiSpecialChar.OPEN_PAREN
       ]);
-      if (typeof patternKey == 'string') {
+      if (typeof patternKey === 'string') {
         // patternKey is a regex
         content.push('/' + patternKey + '/');
       } else {
@@ -167,7 +169,6 @@ export function generateObjectJoi(schema: JoiObject): JoiStatement[] {
       content.push(JoiSpecialChar.COMMA);
 
       content.push(...generateJoi(subSchema));
-      //content.push(...generateAnyJoi(subSchema));
 
       content.push(JoiSpecialChar.CLOSE_PAREN);
     });
@@ -177,7 +178,7 @@ export function generateObjectJoi(schema: JoiObject): JoiStatement[] {
     _.keys(schema.with).forEach((key) => {
       const dependencies = schemaWith[key];
       content.push(...['.with', JoiSpecialChar.OPEN_PAREN]);
-      //content.push(JoiSpecialChar.)
+      // content.push(JoiSpecialChar.)
       content.push('\'' + key + '\'');
 
       content.push(JoiSpecialChar.COMMA);
@@ -188,10 +189,10 @@ export function generateObjectJoi(schema: JoiObject): JoiStatement[] {
         content.push(JoiSpecialChar.CLOSE_BRACKET);
       } else {
         // TODO Joi.with() can't not support object dependencies
-        //content.push(...generateJoi(dependencies));
+        // content.push(...generateJoi(dependencies));
       }
-      content.push(JoiSpecialChar.CLOSE_PAREN)
-    })
+      content.push(JoiSpecialChar.CLOSE_PAREN);
+    });
   }
   content.push(...generateAnyJoi(schema));
 

--- a/src/joi/object.ts
+++ b/src/joi/object.ts
@@ -171,8 +171,12 @@ export function generateObjectJoi(schema: JoiObject): JoiStatement[] {
       content.push(...generateJoi(subSchema));
 
       content.push(JoiSpecialChar.CLOSE_PAREN);
+
+      content.push('\n');
     });
+
   }
+
   if (schema.with) {
     const schemaWith = schema.with;
     _.keys(schema.with).forEach((key) => {
@@ -185,13 +189,14 @@ export function generateObjectJoi(schema: JoiObject): JoiStatement[] {
 
       if (_.isArray(dependencies)) {
         content.push(JoiSpecialChar.OPEN_BRACKET);
-        content.push(...stringifyOutputString(dependencies));
+        content.push(stringifyOutputString(dependencies).join(','));
         content.push(JoiSpecialChar.CLOSE_BRACKET);
       } else {
         // TODO Joi.with() can't not support object dependencies
         // content.push(...generateJoi(dependencies));
       }
       content.push(JoiSpecialChar.CLOSE_PAREN);
+      content.push('\n');
     });
   }
   content.push(...generateAnyJoi(schema));

--- a/src/joi/object.ts
+++ b/src/joi/object.ts
@@ -6,7 +6,7 @@ import * as _ from 'lodash';
 import { resolveJSONSchema } from './resolve';
 import { generateAnyJoi, generateJoi, JoiStatement, JoiSpecialChar, openJoi, closeJoi } from './generate';
 import { Options } from './options';
-import {stringifyOutputString} from '../utils';
+import { stringifyOutputString } from '../utils';
 
 function resolveProperties(schema: JSONSchema4, options?: Options): { [k: string]: JoiSchema } | undefined {
   const properties = schema.properties;
@@ -63,27 +63,27 @@ export function resolveJoiObjectSchema(schema: JSONSchema4, options?: Options): 
   }
   // https://json-schema.org/understanding-json-schema/reference/object.html#size
   // tslint:disable:no-unused-expression-chai
-  if(_.isNumber(schema.minProperties) && _.isNumber(schema.maxProperties) && schema.maxProperties == schema.minProperties) {
-    joiSchema.length = schema.maxProperties ;
-  }else{
+  if (_.isNumber(schema.minProperties) && _.isNumber(schema.maxProperties) && schema.maxProperties == schema.minProperties) {
+    joiSchema.length = schema.maxProperties;
+  } else {
     _.isNumber(schema.minProperties) && (joiSchema.min = schema.minProperties);
     _.isNumber(schema.maxProperties) && (joiSchema.max = schema.maxProperties);
   }
   // tslint:enable:no-unused-expression-chai
   // TODO: Dependencies
   // https://json-schema.org/understanding-json-schema/reference/object.html#dependencies
-  if(schema.dependencies !== undefined){
+  if (schema.dependencies !== undefined) {
     // the properties which need dependencies
     let dependencies: string[] = _.keys(schema.dependencies);
     const schemaDepencies = schema.dependencies;
     joiSchema.with = {};
     const joiSchemaWith = joiSchema.with;
-    dependencies.forEach((key)=>{
+    dependencies.forEach((key) => {
       // https://json-schema.org/understanding-json-schema/reference/object.html#dependencies
-      if(_.isArray(schemaDepencies[key])){
-        const properties:string[] = schemaDepencies[key] as string[];
+      if (_.isArray(schemaDepencies[key])) {
+        const properties: string[] = schemaDepencies[key] as string[];
         joiSchemaWith[key] = properties;
-      }else{
+      } else {
         // TODO Joi.with() can't not support object dependencies
         // joiSchemaWith[key] = resolveJSONSchema(schemaDepencies[key],options)
       }
@@ -91,17 +91,17 @@ export function resolveJoiObjectSchema(schema: JSONSchema4, options?: Options): 
   }
   // TODO: Pattern Properties
   // https://json-schema.org/understanding-json-schema/reference/object.html#pattern-properties
-  if(schema.patternProperties !== undefined){
+  if (schema.patternProperties !== undefined) {
     let propertiesPattern: string[] = _.keys(schema.patternProperties);
-    if(joiSchema.pattern === undefined) joiSchema.pattern = [];
+    if (joiSchema.pattern === undefined) joiSchema.pattern = [];
     // Compiling will fail without the following two local variable declearations.
     const joiSchemaPattern = joiSchema.pattern;
     const schemaPatternProperties = schema.patternProperties;
-    propertiesPattern.forEach((keyPattern:string)=>{
-        joiSchemaPattern.push({
-          pattern: keyPattern,
-          schema: resolveJSONSchema(schemaPatternProperties[keyPattern],options),
-        })
+    propertiesPattern.forEach((keyPattern: string) => {
+      joiSchemaPattern.push({
+        pattern: keyPattern,
+        schema: resolveJSONSchema(schemaPatternProperties[keyPattern], options),
+      })
     })
   }
   return joiSchema;
@@ -147,11 +147,11 @@ export function generateObjectJoi(schema: JoiObject): JoiStatement[] {
   if (schema.min !== undefined) {
     content.push(`.min(${schema.min})`);
   }
-  if (schema.length !== undefined ){
+  if (schema.length !== undefined) {
     content.push(`.length(${schema.length})`);
   }
   if (schema.pattern) {
-    schema.pattern.forEach((pattern)=>{
+    schema.pattern.forEach((pattern) => {
       const patternKey = pattern.pattern;
       const subSchema = pattern.schema; // JoiSchema
       content.push(...[
@@ -160,33 +160,33 @@ export function generateObjectJoi(schema: JoiObject): JoiStatement[] {
       ]);
       if (typeof patternKey == 'string') {
         // patternKey is a regex
-        content.push('/'+ patternKey+'/');
+        content.push('/' + patternKey + '/');
       } else {
         content.push(...generateJoi(patternKey));
       }
       content.push(JoiSpecialChar.COMMA);
-      
+
       content.push(...generateJoi(subSchema));
       //content.push(...generateAnyJoi(subSchema));
 
       content.push(JoiSpecialChar.CLOSE_PAREN);
     });
   }
-  if (schema.with){
+  if (schema.with) {
     const schemaWith = schema.with;
-    _.keys(schema.with).forEach((key)=>{
+    _.keys(schema.with).forEach((key) => {
       const dependencies = schemaWith[key];
-      content.push(...['.with',JoiSpecialChar.OPEN_PAREN]);
+      content.push(...['.with', JoiSpecialChar.OPEN_PAREN]);
       //content.push(JoiSpecialChar.)
-      content.push('\''+key+'\'');
+      content.push('\'' + key + '\'');
 
       content.push(JoiSpecialChar.COMMA);
 
-      if(_.isArray(dependencies)){
+      if (_.isArray(dependencies)) {
         content.push(JoiSpecialChar.OPEN_BRACKET);
         content.push(...stringifyOutputString(dependencies));
         content.push(JoiSpecialChar.CLOSE_BRACKET);
-      }else{
+      } else {
         // TODO Joi.with() can't not support object dependencies
         //content.push(...generateJoi(dependencies));
       }

--- a/src/joi/object.ts
+++ b/src/joi/object.ts
@@ -86,8 +86,10 @@ export function resolveJoiObjectSchema(schema: JSONSchema4, options?: Options): 
         const properties: string[] = schemaDepencies[key] as string[];
         joiSchemaWith[key] = properties;
       } else {
-        // TODO Joi.with() can't not support object dependencies
-        // joiSchemaWith[key] = resolveJSONSchema(schemaDepencies[key],options)
+        if (joiSchema.keys === undefined) { joiSchema.keys = {}; }
+        const newKey: string = key + '_dependency';
+        joiSchema.keys[newKey] = resolveJSONSchema(schemaDepencies[key], options);
+        joiSchemaWith[key] = [newKey];
       }
     });
   }
@@ -192,9 +194,6 @@ export function generateObjectJoi(schema: JoiObject): JoiStatement[] {
         content.push(stringifyOutputString(dependencies).join(','));
         content.push(JoiSpecialChar.CLOSE_BRACKET);
         content.push(' ');
-      } else {
-        // TODO Joi.with() can't not support object dependencies
-        // content.push(...generateJoi(dependencies));
       }
       content.push(JoiSpecialChar.CLOSE_PAREN);
 

--- a/src/joi/types.ts
+++ b/src/joi/types.ts
@@ -78,7 +78,7 @@ export interface JoiObject extends JoiAny {
   xor?: string[];
   oxor?: string[];
   //with?: string[];
-  with?: { 
+  with?: {
     [k: string]: string[] | JoiSchema;
   };
   without?: string[];

--- a/src/joi/types.ts
+++ b/src/joi/types.ts
@@ -71,7 +71,7 @@ export interface JoiObject extends JoiAny {
   pattern?: {
     pattern: JoiSchema | string;
     schema: JoiSchema;
-  }[];
+  }[]; // modified to array type
   and?: string[];
   nand?: string[];
   or?: string[];

--- a/src/joi/types.ts
+++ b/src/joi/types.ts
@@ -71,13 +71,16 @@ export interface JoiObject extends JoiAny {
   pattern?: {
     pattern: JoiSchema | string;
     schema: JoiSchema;
-  };
+  }[];
   and?: string[];
   nand?: string[];
   or?: string[];
   xor?: string[];
   oxor?: string[];
-  with?: string[];
+  //with?: string[];
+  with?: { 
+    [k: string]: string[] | JoiSchema;
+  };
   without?: string[];
   unknown?: boolean;
 }

--- a/src/joi/types.ts
+++ b/src/joi/types.ts
@@ -68,16 +68,16 @@ export interface JoiObject extends JoiAny {
   min?: number;
   max?: number;
   length?: number;
-  pattern?: {
+  pattern?: Array<{
     pattern: JoiSchema | string;
     schema: JoiSchema;
-  }[]; // modified to array type
+  }>; // modified to array type
   and?: string[];
   nand?: string[];
   or?: string[];
   xor?: string[];
   oxor?: string[];
-  //with?: string[];
+  // with?: string[];
   with?: {
     [k: string]: string[] | JoiSchema;
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,10 +17,10 @@ export async function traverseDir(
   }
 }
 
-export function stringifyOutputString(inStr: string[]): string[]{
+export function stringifyOutputString(inStr: string[]): string[] {
   let result: string[] = [];
-  inStr.forEach((str)=>{
-    result.push('\''+str+'\'');
+  inStr.forEach((str) => {
+    result.push('\'' + str + '\'');
   })
   return result;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,9 +18,9 @@ export async function traverseDir(
 }
 
 export function stringifyOutputString(inStr: string[]): string[] {
-  let result: string[] = [];
+  const result: string[] = [];
   inStr.forEach((str) => {
     result.push('\'' + str + '\'');
-  })
+  });
   return result;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,3 +16,11 @@ export async function traverseDir(
     }
   }
 }
+
+export function stringifyOutputString(inStr: string[]): string[]{
+  let result: string[] = [];
+  inStr.forEach((str)=>{
+    result.push('\''+str+'\'');
+  })
+  return result;
+}

--- a/test/joi/test-object.ts
+++ b/test/joi/test-object.ts
@@ -11,6 +11,205 @@ const objectJSONSchemaTemplate: JSONSchema4 = {
 
 const testItems: TestItem[] = [
   {
+    title: 'complicated example',
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        credit_card: { type: 'number' },
+        billing_address: { type: 'string' },
+        username: {
+          type: 'string',
+          maxLength: 100
+        }
+      },
+      required: ['name'],
+      patternProperties: {
+        '^S_': { type: 'string' },
+        '^I_': { type: 'integer' }
+      },
+      additionalProperties: false,
+      dependencies: {
+        username: ['credit_card', 'billing_address', 'name'],
+        name: {
+          type: 'string',
+          maxLength: 120
+        }
+      }
+    },
+    targetJoiSchema: {
+      type: 'object',
+      keys: {
+        name: { type: 'string', required: true },
+        credit_card: { type: 'number' },
+        billing_address: { type: 'string' },
+        username: { type: 'string', max: 100 },
+        name_dependency: { type: 'string', max: 120 },
+      },
+      with: {
+        username: ['credit_card', 'billing_address', 'name'],
+        name: ['name_dependency']
+      },
+      pattern: [
+        {
+          pattern: '^S_',
+          schema: { type: 'string' }
+        },
+        {
+          pattern: '^I_',
+          schema: { type: 'number', integer: true }
+        }
+      ],
+      unknown: false
+    },
+    targetJoiString:
+      'Joi.object().keys({\n' +
+      '  name: Joi.string().required(),\n' +
+      '  credit_card: Joi.number(),\n' +
+      '  billing_address: Joi.string(),\n' +
+      '  username: Joi.string().max(100),\n' +
+      '  name_dependency: Joi.string().max(120),\n' +
+      '}).pattern(/^S_/,Joi.string())\n' +
+      '.pattern(/^I_/,Joi.number().integer())\n' +
+      '.with(\'username\', [\'credit_card\',\'billing_address\',\'name\'] )\n' +
+      '.with(\'name\', [\'name_dependency\'] )\n' +
+      '.unknown(false)'
+  },
+  {
+    title: 'with schema dependencies',
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        credit_card: { type: 'number' }
+      },
+      required: ['name'],
+      dependencies: {
+        credit_card: {
+          properties: {
+            billing_address: { type: 'string' }
+          },
+          required: ['billing_address']
+        }
+      }
+    },
+    targetJoiSchema: {
+      type: 'object',
+      keys: {
+        name: { type: 'string', required: true },
+        credit_card: { type: 'number' },
+        credit_card_dependency: {
+          type: 'object',
+          keys: {
+            billing_address: { type: 'string', required: true }
+          },
+          unknown: true
+        }
+      },
+      with: {
+        credit_card: ['credit_card_dependency']
+      },
+      unknown: true
+    },
+    targetJoiString:
+      'Joi.object().keys({\n' +
+      '  name: Joi.string().required(),\n' +
+      '  credit_card: Joi.number(),\n' +
+      '  credit_card_dependency: Joi.object().keys({\n' +
+      '    billing_address: Joi.string().required(),\n' +
+      '  }).unknown(),\n' +
+      '}).with(\'credit_card\', [\'credit_card_dependency\'] )\n' +
+      '.unknown()'
+  },
+  {
+    title: 'with property dependencies',
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        credit_card: { type: 'number' },
+        billing_address: { type: 'string' }
+      },
+      required: ['name'],
+      dependencies: {
+        credit_card: ['billing_address', 'name']
+      }
+    },
+    targetJoiSchema: {
+      type: 'object',
+      keys: {
+        name: { type: 'string', required: true },
+        credit_card: { type: 'number' },
+        billing_address: { type: 'string' }
+      },
+      with: {
+        credit_card: ['billing_address', 'name']
+      },
+      unknown: true
+    },
+    targetJoiString:
+      'Joi.object().keys({\n' +
+      '  name: Joi.string().required(),\n' +
+      '  credit_card: Joi.number(),\n' +
+      '  billing_address: Joi.string(),\n' +
+      '}).with(\'credit_card\', [\'billing_address\',\'name\'] )\n' +
+      '.unknown()'
+  },
+  {
+    title: 'pattern dependencies',
+    schema: {
+      type: 'object',
+      properties: {
+        builtin: { type: 'number' }
+      },
+      patternProperties: {
+        '^S_': { type: 'string' },
+        '^I_': { type: 'integer' }
+      },
+      additionalProperties: { type: 'string' }
+    },
+    targetJoiSchema: {
+      type: 'object',
+      keys: { builtin: { type: 'number' } },
+      pattern: [
+        {
+          pattern: '^',
+          schema: { type: 'string' }
+        },
+        {
+          pattern: '^S_',
+          schema: { type: 'string' }
+        },
+        {
+          pattern: '^I_',
+          schema: { type: 'number', integer: true }
+        }
+      ]
+    },
+    targetJoiString:
+      'Joi.object().keys({\n' +
+      '  builtin: Joi.number(),\n' +
+      '}).pattern(/^/,Joi.string())\n' +
+      '.pattern(/^S_/,Joi.string())\n' +
+      '.pattern(/^I_/,Joi.number().integer())'
+  },
+  {
+    title: 'length',
+    schema: {
+      type: 'object',
+      minProperties: 3,
+      maxProperties: 3
+    },
+    targetJoiSchema: {
+      type: 'object',
+      keys: undefined,
+      unknown: true,
+      length: 3
+    },
+    targetJoiString:
+      'Joi.object().length(3).unknown()'
+  },
+  {
     title: 'properties',
     schema: {
       properties: {


### PR DESCRIPTION
Compromise solution for supporting [schema dependencies](https://json-schema.org/understanding-json-schema/reference/object.html#schema-dependencies).
"Joi" can only support [property dependencies](https://json-schema.org/understanding-json-schema/reference/object.html#property-dependencies), To support schema dependencies, I implements it by adding a new property into keys and adding it as property-dependencies.